### PR TITLE
upgrade manifest to v3

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -31,7 +31,7 @@ chrome.runtime.onMessage.addListener(
                 // create new windows for the transfer funds
                 let url='window.html?command=transfer&recipient='+encodeURI(request.recipient)+'&amount='+encodeURI(request.amount)+'&domain='+encodeURI(request.domain);
                 chrome.tabs.create({
-                    url: chrome.extension.getURL(url),
+                    url: chrome.runtime.getURL(url),
                     active: false
                 }, function(tab) {
                     // After the tab has been created, open a window to inject the tab
@@ -70,7 +70,7 @@ chrome.runtime.onMessage.addListener(
                 // create new windows for the extrinsic
                 let url='window.html?command=tx&recipient='+encodeURI(request.recipient)+'&pallet='+encodeURI(request.pallet)+'&call='+encodeURI(request.call)+'&parameters='+encodeURI(request.parameters)+'&domain='+encodeURI(request.domain);
                 chrome.tabs.create({
-                    url: chrome.extension.getURL(url),
+                    url: chrome.runtime.getURL(url),
                     active: false
                 }, function(tab) {
                     // After the tab has been created, open a window to inject the tab
@@ -109,7 +109,7 @@ chrome.runtime.onMessage.addListener(
             // create new windows for authentication
             let url='window.html?command=signin&domain='+encodeURI(request.domain);
             chrome.tabs.create({
-                url: chrome.extension.getURL(url),
+                url: chrome.runtime.getURL(url),
                 active: false
             }, function(tab) {
                 // After the tab has been created, open a window to inject the tab

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,30 +1,38 @@
 {
-"manifest_version": 2,
-"name": "BitgreenWallet",
-"description": "Bitgreen Browser Wallet",
-"version": "0.2",
-"browser_action": {
+  "manifest_version": 3,
+  "name": "BitgreenWallet",
+  "description": "Bitgreen Browser Wallet",
+  "version": "0.2",
+  "action": {
     "default_icon": "icon.png",
     "default_popup": "window.html"
-    },
-"permissions": [
+  },
+  "permissions": [
     "clipboardRead",
     "clipboardWrite",
     "storage",
     "tabs",
     "scripting",
-    "system.display",
+    "system.display"
+  ],
+  "host_permissions": [
     "https://testnet.bitgreen.org:9443/",
     "https://mainnet.bitgreen.org:9443/"
   ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["contentscript.js"]
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "contentscript.js"
+      ]
     }
   ],
   "background": {
     "service_worker": "background.js"
   },
-"content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'"
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  }
 }

--- a/chrome-extension/wallet.js
+++ b/chrome-extension/wallet.js
@@ -1,5 +1,4 @@
 //TODO:  change account description, remove account, copy account without hidden field, improve support link
-// update manifest to ver. 3.0
 // TODO set a red light and switch to green when connected
 // evaluate the encryption of account description and account code (better privacy)
 // ask for access password initially to decrypt the data above and keep it open for the session till the browser is open


### PR DESCRIPTION
Upgraded manifest to v3, followed this tutorial: https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
`chrome.extension.getURL()` is deprecated, use `chrome.runtime.getURL()` instead. Source: https://developer.chrome.com/docs/extensions/reference/extension/#method-getURL